### PR TITLE
【Fixed】バリデーション実装、　root path / header link の変更

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ApplicationRecord
   belongs_to :blog
   belongs_to :user
-  validates :content, presence: true
+  validates :content, presence: true, length: { in: 1..100 }
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -2,6 +2,7 @@ class Place < ApplicationRecord
   mount_uploader :image, ImageUploader
   validates :name, presence: true
   validates :address, presence: true
+  validates :description, length: { in: 1..100 }
   has_one :rule, dependent: :destroy, autosave: true
   accepts_nested_attributes_for :rule, 
                                 allow_destroy: true,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
   <body>
     <header>
       <nav class="navbar navbar-expand-lg navbar-light">
-        <%= link_to "NO MORE garbo", blogs_path, class: "nav-link no_more_garbo" %>
+        <%= link_to "NO MORE garbo", places_path, class: "nav-link no_more_garbo" %>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           LINK
           <span class="navbar-toggler-icon"></span>

--- a/app/views/users/user_blogs.html.erb
+++ b/app/views/users/user_blogs.html.erb
@@ -11,7 +11,7 @@
       <div class="col-md-8">
         <div class="card-body user_blogs_content">
           <h5 class="card-title"><%= blog.title %></h5>
-          <p class="card-text"><%= blog.created_at %></p>
+          <p class="card-text"><%= blog.created_at.strftime("%Y-%m-%d %H:%M") %></p>
           <p class="card-text"><%= blog.content %></p>
         </div>
         <%= link_to '詳細', blog_path(blog), class: "btn btn-outline-success" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
     end
   end
   resources :favorites, only: [:create, :destroy]
-  root 'blogs#index'
+  root 'places#index'
   resources :blogs do
     collection do
       post :confirm


### PR DESCRIPTION
#26

- comment　長さを100文字まで
-  place description 長さを100文字まで
-  no more garboリンク先とroot path変更
-  user_blogs のcreated_atの表示を年月時間のみに変更